### PR TITLE
added fix inputs dialog option (just ui)

### DIFF
--- a/src/challenge/HeaderBar.tsx
+++ b/src/challenge/HeaderBar.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 
 import {
   Toolbar,
@@ -13,7 +13,9 @@ import {
 
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import QuestionMarkIcon from "@mui/icons-material/QuestionMark";
+import ArticleIcon from "@mui/icons-material/Article";
 import Menu from "../components/Menu";
+import InputsDialog from "../components/InputsDialog";
 import FileUploadControl from "../components/FileUploadControl";
 
 type HeaderBarProps = {
@@ -28,6 +30,9 @@ type HeaderBarProps = {
 };
 
 const HeaderBar = (props: HeaderBarProps) => {
+
+  const inputsDialog = useRef<HTMLDivElement>(null);
+
   return (
     <Toolbar variant="dense" sx={{ paddingTop: "2px" }}>
       <Grid container spacing={2} style={{ display: "flex" }}>
@@ -103,6 +108,12 @@ const HeaderBar = (props: HeaderBarProps) => {
               </ListItemIcon>
               Help
             </MenuItem>
+            <MenuItem>
+              <ListItemIcon>
+                <ArticleIcon />
+              </ListItemIcon>
+              <InputsDialog ref={inputsDialog}/>
+            </MenuItem>            
           </Menu>
         </Grid>
       </Grid>

--- a/src/components/InputsDialog.tsx
+++ b/src/components/InputsDialog.tsx
@@ -1,0 +1,72 @@
+import React, { useRef } from 'react';
+import { TextField, Box, Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle} from "@mui/material";
+
+const InputsDialog = React.forwardRef<HTMLDivElement>((props, ref) => {  
+  
+  const txtInputs = useRef<HTMLInputElement>(null);
+  const [open, setOpen] = React.useState(false);
+  const [contents, setContents] = React.useState("");
+  const [readonly, setReadonly] = React.useState(true);
+  
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+  };
+
+  const handleActivate= () => {
+    setReadonly(false);
+  };
+
+  const handleDeactivate= () => {
+    setReadonly(true);
+  };  
+
+  return (
+    <div>
+      <Box onClick={handleClickOpen}>
+        Fix inputs
+      </Box>
+      <Dialog open={open} onClose={handleClose} aria-labelledby="form-dialog-title">
+        <DialogTitle id="form-dialog-title">Set Debug Input</DialogTitle>
+        <DialogContent>
+          <DialogContentText>
+            Any text here will be used as line-by-line input instead of prompting from the console. It will be reset for each new challenge.
+          </DialogContentText>
+          <TextField
+            ref={txtInputs}
+            margin="dense"
+            multiline
+            rows={8}
+            id="input"
+            label="Input"
+            type="text"
+            fullWidth
+            disabled={readonly}
+            defaultValue={contents}
+            onChange={event => {
+              const { value } = event.target;
+              setContents(value);
+            }}
+
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleActivate} color="primary">
+            Activate
+          </Button>
+          <Button onClick={handleDeactivate} color="primary">
+            Deactivate
+          </Button>
+          <Button onClick={handleClose} color="primary">
+            Close
+          </Button>                  
+        </DialogActions>
+      </Dialog>
+    </div>
+  );
+});
+
+export default InputsDialog;


### PR DESCRIPTION
Not sure we want this or if a better way ... added a pop up inputs dialog to the menu for fixing inputs which could then be activated or deactivated but either way would reset for the next challenge. Not linked up to the inputs however yet plus I can't quite figure out interface references yet so for the moment InputDialog uses a react.forwardRef<HTMLDivElement>but I want it to have its own ref interface so that I can trigger the button click if you click anywhere on that menu icon and not just specifically on the button.