### PR TITLE
added contains and not contains option

### DIFF
--- a/public/examples/book.json
+++ b/public/examples/book.json
@@ -29,7 +29,7 @@
             "tests": [
                 {
                     "in": "Joe",
-                    "out": ".*Hello Joe\n"
+                    "out": "{@Hello,Joe,~hello@}"
                 }
             ]
         },


### PR DESCRIPTION
using format for json out case: e.g. "out": "{@Hello,Joe,~hello@}"

What do you think? e.g. to avoid complicating the json format have various out format options e.g. {@ ... @} for contains/doesn't contain output matching using comma separation and ~ for not contains? Tested it out on Hello name exercise.