### PR TITLE
Added BookNodeModel support for advancedTests

### DIFF
--- a/src/book/components/BookEditorDrawer.tsx
+++ b/src/book/components/BookEditorDrawer.tsx
@@ -28,6 +28,7 @@ const BookEditorDrawer = (props: BookEditorDrawerProps) => {
       id,
       name: "New page",
       tests: [],
+      advancedTests: [],
       py: `${id}.py`,
       guide: `${id}.md`,
     };

--- a/src/challenge/Challenge.tsx
+++ b/src/challenge/Challenge.tsx
@@ -26,6 +26,7 @@ import BookControlFabs from "../book/components/BookControlFabs";
 import HeaderBar from "../components/HeaderBar";
 import ChallengeStatus from "../models/ChallengeStatus";
 import { TestCases } from "../models/Tests";
+import { AdvancedTestCases } from "../models/AdvancedTests";
 import Help from "./components/Help";
 import Outputs, { OutputsHandle } from "./components/Outputs";
 import BookUploadModal from "../book/components/BookUploadModal";
@@ -47,6 +48,7 @@ type ChallengeState = IChallengeState & {
 type ChallengeProps = IChallengeProps & {
   title?: string;
   tests?: TestCases | null;
+  advancedTests?: AdvancedTestCases | null;
   openBookDrawer?: (open: boolean) => void;
   onRequestPreviousChallenge?: () => void;
   onRequestNextChallenge?: () => void;

--- a/src/challenge/ChallengeEditor.tsx
+++ b/src/challenge/ChallengeEditor.tsx
@@ -137,6 +137,7 @@ class ChallengeEditor
       isExample: node.isExample,
       typ: node.typ,
       tests: node.tests,
+      advancedTests: node.advancedTests
     };
     return JSON.stringify(proxy, null, 2);
   }
@@ -282,6 +283,10 @@ class ChallengeEditor
       changed = true;
       this.props.bookNode.tests = editedNode.tests;
     }
+    if (editedNode.advancedTests !== this.props.advancedTests) {
+      changed = true;
+      this.props.bookNode.advancedTests = editedNode.advancedTests;
+    }    
     if (changed) {
       this.props.bookStore.store.saveBook();
       this.props.onBookModified();

--- a/src/challenge/IChallenge.ts
+++ b/src/challenge/IChallenge.ts
@@ -13,10 +13,12 @@ import IBookFetcher from "../book/utils/IBookFetcher";
 import { SessionContextType } from "../auth/SessionContext";
 import { ProgressStorage } from "../book/utils/ProgressStorage";
 import BookNodeModel from "../models/BookNodeModel";
+import { AdvancedTestCases } from "../models/AdvancedTests";
 
 type IChallengeProps = {
   uid: string;
   tests?: TestCases | null;
+  advancedTests?: AdvancedTestCases | null;
   isExample?: boolean;
   guidePath: string;
   codePath: string;

--- a/src/models/AdvancedTests.ts
+++ b/src/models/AdvancedTests.ts
@@ -1,0 +1,15 @@
+type AdvancedTestCaseMatch = {
+  typ: "+" | "-";
+  match: string;
+  ignore?: string;
+  multi?: number;
+}
+
+type AdvancedTestCase = {
+  in: Array<string>;
+  out: Array<AdvancedTestCaseMatch>;
+};
+
+type AdvancedTestCases = Array<AdvancedTestCase>;
+
+export { AdvancedTestCase, AdvancedTestCases};

--- a/src/models/BookNodeModel.ts
+++ b/src/models/BookNodeModel.ts
@@ -1,4 +1,5 @@
 import { TestCases } from "./Tests";
+import { AdvancedTestCases } from "./AdvancedTests";
 
 type BookNodeModel = {
   name: string;
@@ -7,6 +8,7 @@ type BookNodeModel = {
   py?: string;
   guide?: string;
   tests: TestCases;
+  advancedTests: AdvancedTestCases;
   bookLink?: string;
   isExample?: boolean;
   typ?: "py" | "parsons" | "canvas";
@@ -239,7 +241,7 @@ const _extractIdsWithTestsInOrder = (
   node: BookNodeModel,
   arr: Array<string>
 ) => {
-  if (node.isExample || node.tests || node.typ === "parsons") arr.push(node.id);
+  if (node.isExample || node.tests || node.advancedTests || node.typ === "parsons") arr.push(node.id);
   if (node.children) {
     for (let child of node.children) {
       _extractIdsWithTestsInOrder(child, arr);


### PR DESCRIPTION
SUPPORTED IN JSON but not currently tested for pass/fail during testing e.g. below - see DJG doc suggestion
{
  "name": "Hello world",
  "tests": [
    {
      "in": "",
      "out": "hello world"
    }
  ],
  "advancedTests": [
    {
      "in": ["hello", "5"],
      "out":[
        {"typ":"+", "match":"hello", "ignore":"c", "multi":"5"},
        {"typ":"-", "match":"hello", "ignore":"c", "multi":"6"}
      ]
    }
  ]
}