### PR TITLE
Advanced testcases union

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,36 @@ An updated test case might look like this:
 The `"in"` property can be a string, such as `"in": "Alice"`. If you pick this option, then you can use the `\n` character to enter multiple lines of text.
 However, `"in"` can be also provided as a list of string/numerical values, such as `"in": ["Joe", 5, 2, "yes"]`.
 
+The `"out"` property can be a string, such as `"Hello Alice"`. If you pick this option, then you can use the `\n` to match new lines and `.*` to match anything up to the end of a line. Blank new lines at the end of the output are ignored. Comparison is case sensitive.
+
+However, `"out"` can be also provided as a list of matching requirements, where each requirement contains a
+* `pattern` is a regular expression. Note that `\` needs to be escaped in json, so `\\d` means a digit.
+* optional `typ`:
+  * `+` means output must match this requirement (default)
+  * `-` means output must match this requirement
+* optional `ignore`: each output requirement can include `ignore` flags so that tests can pass with slight differences to the expected output, as students can make small mistakes that are not relevant to the overall pass/fail result. 3 classes of errors that can be ignored are **w**hitespace, **p**unctuation and **c**apitalization (case) of text. If the difference between the expected and actual output fall into an ignore class, then the test should pass. This is given as a string of flag initial letter.
+* `count`: interpreted to mean that the output must occur exactly `count` number of times. If not given, this defaults to -1, which means we don't care how many times the match occured. A `count` with a type `–` means that the string must not occur **exactly** `count` times.
+
+E.g.
+
+```json
+"tests": [
+  {
+    "in": [4, 5],
+    "out": [
+      {"pattern":"Enter    a;", "ignore":"wcp"},
+      {"pattern":"Enter b:"},
+      {"typ":"-", "pattern":"Hello 3"},
+      {"typ":"+", "pattern":"Hello \\d", "count":2, "ignore":"w"},
+      {"pattern": "sum.*9", "ignore": "wc"}
+    ]
+  }
+]
+```
+
+*potential caveat: these advanced output requirements support regexes, but the use of the ignore flags can conflict with complex expressions. Regex supports case insensitive comparisons, but white space ignores are achieved by stripping white spaces and punctuation ignores are achieved by stripping punctuations. To avoid any conflicts, avoid using additional punctuations in your regex when using these flags. E.g. `Hello .* how are you` is fine, but `Hello .*, how are you` is risky.*
+
+
 # Contributing to the project
 We welcome code additions to this github repo via PRs as long as they are in-line with the original design intentions of the project:
 * lightweight in-browser client-side code execution

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Ideal for keeping track of progress, when you give a chance for your students to
 `tests` is a list of test cases.
 
 ## Test cases
-Each test case has an `input` and `output` field. The input field specifies how the tester will respond to `input()` command, while the `output` is checked against all printed output (ignoring leading/trailing spaces and new lines). Lines are split on `\n` characters. `output` handles within-line `.*` wildcards,
+Each test case has an `input` and `output` field. The input field specifies how the tester will respond to `input()` command, while the `output` is checked against all printed output (ignoring leading/trailing spaces and new lines). In the simplest setup, lines are split on `\n` characters. `output` handles within-line `.*` wildcards.
 
 ### example
 For a short case study, let's imagine the student has to write a program which inputs two numbers, then outputs the larger one.
@@ -185,6 +185,10 @@ An updated test case might look like this:
   "out": ".*\n.*\n6"
 }
 ```
+
+## More formally (advanced testing options)
+The `"in"` property can be a string, such as `"in": "Alice"`. If you pick this option, then you can use the `\n` character to enter multiple lines of text.
+However, `"in"` can be also provided as a list of string/numerical values, such as `"in": ["Joe", 5, 2, "yes"]`.
 
 # Contributing to the project
 We welcome code additions to this github repo via PRs as long as they are in-line with the original design intentions of the project:

--- a/bookSchema.json
+++ b/bookSchema.json
@@ -116,11 +116,13 @@
             ]
           },
           "out": {
-            "oneOf": [{
-              "description": "stdout to compare to. Use .* to match a line (but not the new line). Use \n for line breaks.",
-              "type": "string"
-            },
-                      {"$ref": "#/$defs/advancedOutRequirement"}]
+            "oneOf": [
+              {
+                "description": "stdout to compare to. Use .* to match a line (but not the new line). Use \n for line breaks.",
+                "type": "string"
+              },
+              { "$ref": "#/$defs/advancedOutRequirement" }
+            ]
           },
           "comment": {
             "$ref": "#/$defs/comment"
@@ -172,33 +174,31 @@
       "type": "array",
       "items": {
         "type": "object",
-          "properties": {
-          	"pattern": {
-              "type": "string",
-              "description": "regex pattern to match"
-            },
-            "typ": {
-              "type": "string",
-              "description": "should the output match this requirement or not",
-              "enum": ["+", "-"],
-              "default": "+"
-            },
-            "ignore": {
-            	"type": "string",
-                  "description": "ignore common failures including white spaces, capitalisation(casing), punctionation. Use some combination of wcp",
-                    "default": "",
-                      "enum": ["" , "w" , "c" , "p" , "wc" , "wp" , "cp" , "wcp"]
-                  
-            },
-              "count": {
-                "type": "number",
-                  "default": -1,
-                    "description": "The output must occur (-: not occur) exactly `count` number of times. -1, which is the default, means we don't care."
-              
-              }
+        "properties": {
+          "pattern": {
+            "type": "string",
+            "description": "regex pattern to match"
           },
-         "additionalProperties": false,
-         "required": ["pattern"]
+          "typ": {
+            "type": "string",
+            "description": "should the output match this requirement or not",
+            "enum": ["+", "-"],
+            "default": "+"
+          },
+          "ignore": {
+            "type": "string",
+            "description": "ignore common failures including white spaces, capitalisation(casing), punctionation. Use some combination of wcp",
+            "default": "",
+            "enum": ["", "w", "c", "p", "wc", "wp", "cp", "wcp"]
+          },
+          "count": {
+            "type": "number",
+            "default": -1,
+            "description": "The output must occur (-: not occur) exactly `count` number of times. -1, which is the default, means we don't care."
+          }
+        },
+        "additionalProperties": false,
+        "required": ["pattern"]
       }
     }
   }

--- a/bookSchema.json
+++ b/bookSchema.json
@@ -116,8 +116,11 @@
             ]
           },
           "out": {
-            "description": "stdout to compare to. Use .* to match a line (but not the new line). Use \n for line breaks.",
-            "type": "string"
+            "oneOf": [{
+              "description": "stdout to compare to. Use .* to match a line (but not the new line). Use \n for line breaks.",
+              "type": "string"
+            },
+                      {"$ref": "#/$defs/advancedOutRequirement"}]
           },
           "comment": {
             "$ref": "#/$defs/comment"
@@ -163,6 +166,40 @@
       "readOnly": true,
       "description": "cache; do not use",
       "hidden": true
+    },
+    "advancedOutRequirement": {
+      "description": "output requirement with more control",
+      "type": "array",
+      "items": {
+        "type": "object",
+          "properties": {
+          	"pattern": {
+              "type": "string",
+              "description": "regex pattern to match"
+            },
+            "typ": {
+              "type": "string",
+              "description": "should the output match this requirement or not",
+              "enum": ["+", "-"],
+              "default": "+"
+            },
+            "ignore": {
+            	"type": "string",
+                  "description": "ignore common failures including white spaces, capitalisation(casing), punctionation. Use some combination of wcp",
+                    "default": "",
+                      "enum": ["" , "w" , "c" , "p" , "wc" , "wp" , "cp" , "wcp"]
+                  
+            },
+              "count": {
+                "type": "number",
+                  "default": -1,
+                    "description": "The output must occur (-: not occur) exactly `count` number of times. -1, which is the default, means we don't care."
+              
+              }
+          },
+         "additionalProperties": false,
+         "required": ["pattern"]
+      }
     }
   }
 }

--- a/bookSchema.json
+++ b/bookSchema.json
@@ -53,7 +53,7 @@
         },
         "files": {
           "$ref": "#/$defs/files"
-        },        
+        },
         "comment": {
           "$ref": "#/$defs/comment"
         },
@@ -101,8 +101,19 @@
         "type": "object",
         "properties": {
           "in": {
-            "description": "stdin. Use \n for line breaks",
-            "type": "string"
+            "oneOf": [
+              {
+                "description": "stdin. Use \n for line breaks",
+                "type": "string"
+              },
+              {
+                "description": "stdin. List items will be entered as separate lines",
+                "type": "array",
+                "items": {
+                  "type": ["string", "number"]
+                }
+              }
+            ]
           },
           "out": {
             "description": "stdout to compare to. Use .* to match a line (but not the new line). Use \n for line breaks.",

--- a/public/examples/advanced_tests.md
+++ b/public/examples/advanced_tests.md
@@ -1,0 +1,34 @@
+# Advanced testing
+
+In a simple setup, `in` is a string and `out` is a string. 
+
+However, you can customise your tests further.
+
+## `in`  
+can be a string or a list of things (strings and numbers).
+
+## `out`
+can be a string, or a list of output requirements to be checked, where
+  * `pattern` is a regular expression. Note that `\` needs to be escaped in json, so `\\d` means a digit.
+  * `typ`:
+    * `+` means output must match this requirement (default)
+    * `-` means output must match this requirement
+  * `ignore`: each output requirement can include `ignore` flags so that tests can pass with slight differences to the expected output, as students can make small mistakes that are not relevant to the overall pass/fail result. 3 classes of errors that can be ignored are **w**hitespace, **p**unctuation and **c**apitalization of text. If the difference between the expected and actual output fall into an ignore class, then the test should pass. This is given as a string of flag initial letter.
+  * `count`: interpreted to mean that the output must occur exactly `count` number of times. If not given, this defaults to -1, which means we don't care how many times the match occured. A `count` with a type `–` means that the string must not occur **exactly** `count` times.
+
+  E.g.
+
+```json
+"tests": [
+  {
+    "in": [4, 5],
+    "out": [
+      {"pattern":"Enter    a;", "ignore":"wcp"},
+      {"pattern":"Enter b:"},
+      {"typ":"-", "pattern":"Hello 3"},
+      {"typ":"+", "pattern":"Hello \\d", "count":2, "ignore":"w"},
+      {"pattern": "sum.*9", "ignore": "wc"}
+    ]
+  }
+]
+```

--- a/public/examples/advanced_tests.py
+++ b/public/examples/advanced_tests.py
@@ -1,0 +1,7 @@
+a = int(input("Enter a:"))
+b = int(input("Enter b:"))
+
+print(f"Hello {a}")
+print(f"Hello {b}")
+print(f"The sum is {a+b}")
+

--- a/public/examples/book.json
+++ b/public/examples/book.json
@@ -34,6 +34,24 @@
             ]
         },
         {
+            "id": "d6824412-d643-4f1f-8aa5-e257e5a4fa80",
+            "name": "Advanced testing",
+            "guide": "advanced_tests.md",
+            "py": "advanced_tests.py",
+            "tests": [
+                {
+                    "in": [4, 5],
+                    "out": [
+                        {"pattern":"Enter    a;", "ignore":"wcp"},
+                        {"pattern":"Enter b:"},
+                        {"typ":"-", "pattern":"Hello 3"},
+                        {"typ":"+", "pattern":"Hello \\d", "count":"2", "ignore":"w"},
+                        {"pattern": "sum.*9", "ignore": "wc"}
+                    ]
+                }
+            ]
+        },
+        {
             "id": "a071846a-8f41-4047-aef1-f7370affeffb",
             "name": "Test with wildcard",
             "guide": "wildcard.md",

--- a/public/examples/c02.md
+++ b/public/examples/c02.md
@@ -5,4 +5,4 @@ You can write any valid markdown; see the reference [here](https://www.markdowng
 
 Once ready, press the `Debug` button on the top. To reset the challenge, press the `reset` button. You can also change the theme of the editor, or pick a different challenge.
 
-**work in progress feature**: you can now also test your answer using the `check it` button.
+You can now also test your answer using the `check it` button.

--- a/public/static/js/init.py
+++ b/public/static/js/init.py
@@ -443,7 +443,13 @@ def pyexec(code, expected_input, expected_output):
     os.system = test_shell
     input = test_input
 
-    test_inputs = expected_input.split("\n") if expected_input else []
+    if not expected_input:
+        test_inputs = []  # no input for this test case
+    elif isinstance(expected_input, str):
+        test_inputs = expected_input.split("\n")  # string input; split it on new lines
+    else:
+        test_inputs = [str(inp) for inp in expected_input]  # must be a list of inputs; cast each to be a string to be safe
+    
     test_outputs = expected_output
 
     test_output.clear()

--- a/public/static/js/init.py
+++ b/public/static/js/init.py
@@ -442,7 +442,7 @@ def pyexec(code, expected_input, expected_output):
     time.sleep = test_sleep
     os.system = test_shell
     input = test_input
-
+    
     if not expected_input:
         test_inputs = []  # no input for this test case
     elif isinstance(expected_input, str):

--- a/public/static/js/init.py
+++ b/public/static/js/init.py
@@ -505,7 +505,7 @@ def pyexec(code, expected_input, expected_output):
                 # similar to whitespace, this is a bit of a hack
                 # remove all punctuations from the actual
                 actual_output = re.sub(r"[^\w*\s]", "", actual_output)
-                # from expected, do a quick hack to remove a few common punctuations including .,?!::;"'
+                # from expected, do a quick hack to remove a few common punctuations including .,?!:;"'
                 # This is not a perfect solution, but it's good enough for most cases
                 pattern = re.sub(r";|:|\\\.|,|\\\?|\\\!|\"|'|\\\/", "", pattern)
             actual_count = len(re.findall(pattern, actual_output, flags))

--- a/src/components/TestResultIndicator.tsx
+++ b/src/components/TestResultIndicator.tsx
@@ -13,7 +13,7 @@ import { TooltipProps, tooltipClasses } from "@mui/material/Tooltip";
 import { styled } from "@mui/material/styles";
 import CancelIcon from "@mui/icons-material/Cancel";
 import DoneIcon from "@mui/icons-material/Done";
-import { TestResults } from "../models/Tests";
+import { TestResults, TestResult } from "../models/Tests";
 
 type TestResultsIndicatorProps = {
   testResults: TestResults;
@@ -30,6 +30,97 @@ const HtmlTooltip = styled(({ className, ...props }: TooltipProps) => (
     border: "1px solid #dadde9",
   },
 }));
+
+const InputDisplay = (props: TestResult) => {
+  const { ins } = props;
+  if (!ins) {
+    return <span></span>;
+  }
+
+  // string with \n in it
+  if (typeof ins === "string") {
+    return (
+      <span>
+        {ins.split("\n").map((x, j) => (
+          <span key={j}>
+            {x}
+            <br />
+          </span>
+        ))}
+      </span>
+    );
+  }
+
+  // must be an array now
+  return (
+    <span>
+      {ins.map((x, j) => (
+        <span key={j}>
+          {x}
+          <br />
+        </span>
+      ))}
+    </span>
+  );
+};
+
+type OptionalSpanProps = {
+  children: React.ReactNode;
+  visible: boolean;
+};
+const OptionalSpan = (props: OptionalSpanProps) => {
+  if (!props.visible) {
+    return <span></span>;
+  }
+
+  return <span>{props.children}</span>;
+};
+
+const ExpectedDisplay = (props: TestResult) => {
+  const { expected, criteriaOutcomes } = props;
+  if (!expected) {
+    return <span></span>;
+  }
+
+  // string with \n in it
+  if (typeof expected === "string") {
+    return (
+      <span>
+        {expected.split("\n").map((x, j) => (
+          <span key={j}>
+            {x}
+            <br />
+          </span>
+        ))}
+      </span>
+    );
+  }
+
+  // must be an array now
+  return (
+    <span>
+      {expected.map((x, j) => (
+        <span key={j}>
+          <span>
+            {criteriaOutcomes?.at(j) ? (
+              <DoneIcon color="success" sx={{ fontSize: "0.8em" }} />
+            ) : (
+              <CancelIcon color="error" sx={{ fontSize: "0.8em" }} />
+            )}
+          </span>{" "}
+          must <OptionalSpan visible={x.typ === "-"}>not </OptionalSpan>
+          contain: <code>{x.pattern}</code>
+          <OptionalSpan visible={x.count !== undefined && x.count != -1}>
+            {" "}
+            {x.count} time{x.count != undefined && x.count > 1 ? "s" : ""}
+          </OptionalSpan>
+          <OptionalSpan visible={!!x.ignore}> ({x.ignore})</OptionalSpan>
+          <br />
+        </span>
+      ))}
+    </span>
+  );
+};
 
 const TestResultsIndicator = (props: TestResultsIndicatorProps) => {
   const [allPassing, setAllPassing] = useState<boolean | null>(null);
@@ -88,20 +179,10 @@ const TestResultsIndicator = (props: TestResultsIndicatorProps) => {
                         </TableCell>
                         <TableCell>{tr.err}</TableCell>
                         <TableCell>
-                          {tr.ins?.split("\n").map((x, j) => (
-                            <span key={j}>
-                              {x}
-                              <br />
-                            </span>
-                          ))}
+                          <InputDisplay {...tr} />
                         </TableCell>
                         <TableCell>
-                          {tr.expected?.split("\n").map((x, j) => (
-                            <span key={j}>
-                              {x}
-                              <br />
-                            </span>
-                          ))}
+                          <ExpectedDisplay {...tr} />
                         </TableCell>
                         <TableCell>
                           {tr.actual?.split("\n").map((x, j) => (

--- a/src/components/TestResultIndicator.tsx
+++ b/src/components/TestResultIndicator.tsx
@@ -110,9 +110,9 @@ const ExpectedDisplay = (props: TestResult) => {
           </span>{" "}
           must <OptionalSpan visible={x.typ === "-"}>not </OptionalSpan>
           contain: <code>{x.pattern}</code>
-          <OptionalSpan visible={x.count !== undefined && x.count != -1}>
+          <OptionalSpan visible={x.count !== undefined && x.count !== -1}>
             {" "}
-            {x.count} time{x.count != undefined && x.count > 1 ? "s" : ""}
+            {x.count} time{x.count !== undefined && x.count > 1 ? "s" : ""}
           </OptionalSpan>
           <OptionalSpan visible={!!x.ignore}> ({x.ignore})</OptionalSpan>
           <br />

--- a/src/models/Tests.ts
+++ b/src/models/Tests.ts
@@ -15,9 +15,10 @@ type TestCases = Array<TestCase>;
 type TestResult = {
   outcome: boolean;
   err?: string;
-  expected?: string;
+  expected?: string | Array<AdvancedOutRequirement>;
+  criteriaOutcomes?: Array<boolean>;
   actual?: string;
-  ins?: string;
+  ins?: string | Array<string | number>;
 };
 
 type TestResults = Array<TestResult>;

--- a/src/models/Tests.ts
+++ b/src/models/Tests.ts
@@ -1,5 +1,5 @@
 type TestCase = {
-  in: string;
+  in: string | Array<string | number>;
   out: string;
 };
 

--- a/src/models/Tests.ts
+++ b/src/models/Tests.ts
@@ -1,6 +1,13 @@
+type AdvancedOutRequirement = {
+  pattern: string;
+  typ?: "+" | "-";
+  ignore?: "" | "w" | "c" | "p" | "wc" | "wp" | "cp" | "wcp";
+  count?: number;
+};
+
 type TestCase = {
   in: string | Array<string | number>;
-  out: string;
+  out: string | Array<AdvancedOutRequirement>;
 };
 
 type TestCases = Array<TestCase>;

--- a/src/utils/pyworker_sw.js
+++ b/src/utils/pyworker_sw.js
@@ -31,6 +31,8 @@ onmessage = function (e) {
       if (err.message.includes('KeyboardInterrupt')) {
         reason = 'interrupt'
       } else {
+        err = err.toString()
+        err = err.replace(/"\<exec\>", line \d+.*(\n.*)*File "<unknown>"/, '<main.py>)')
         workerPrint(err)
         reason = 'error'
       }
@@ -57,6 +59,8 @@ onmessage = function (e) {
     } catch (err) {
       if (err.message.includes('KeyboardInterrupt')) {
         results = e.data.tests.map((t) => { return { outcome: false, err: 'Interrupted', code: e.data.code, bookNode:e.data.bookNode } })
+      } else {
+        console.log('Error while running tests', err);
       }
     }
     self.postMessage({ cmd: 'test-finished', results, code: e.data.code, bookNode:e.data.bookNode })


### PR DESCRIPTION
Reworked Paul's advanced testcases branch to use union types (therefore making use of the existing tests and testresults lists).

Main changes:
* TestCase and TestResult classes updated to include union fields
* book schema updated
* init.py handles the different input and output types (https://github.com/gdenes355/python-frontend/pull/23/files#diff-5bd4c915c996480c8740d1424b51ecbe226b4122221ab444d101aba956f90cfb)
* TestResultIndicator updated to deal with the input and expected fields (convert the union fields into strings in a meaningful way)
![image](https://user-images.githubusercontent.com/8572049/231313477-6d27c4bf-92e3-48c0-bb7d-6a3577f1ca9b.png)

* Updated Readme.md

Example test list:
```
"tests": [
  {
    "in": [4, 5],
    "out": [
      {"pattern":"Enter    a;", "ignore":"wcp"},
      {"pattern":"Enter b:"},
      {"typ":"-", "pattern":"Hello 3"},
      {"typ":"+", "pattern":"Hello \\d", "count":2, "ignore":"w"},
      {"pattern": "sum.*9", "ignore": "wc"}
    ]
  }
]
```

suggested test page: https://deploy-preview-23--gdenes355-python-frontend.netlify.app/?bk=.%2Fexamples%2Fbook.json&chid=d6824412-d643-4f1f-8aa5-e257e5a4fa80