### PR TITLE
support isAssessment flag on book.json

### DIFF
--- a/bookSchema.json
+++ b/bookSchema.json
@@ -48,6 +48,9 @@
         "isExample": {
           "$ref": "#/$defs/isExample"
         },
+        "isAssessment": {
+          "$ref": "#/$defs/isAssessment"
+        },
         "tests": {
           "$ref": "#/$defs/tests"
         },
@@ -94,6 +97,10 @@
       "description": "is this just an example code? Students need to debug example challenges, but no changes are required",
       "type": "boolean"
     },
+    "isAssessment": {
+      "description": "is this for an assessment? Students can submit but will get no test feedback - setting inherited by all children",
+      "type": "boolean"
+    },    
     "tests": {
       "description": "optional list of tests",
       "type": "array",

--- a/src/book/Book.tsx
+++ b/src/book/Book.tsx
@@ -329,6 +329,7 @@ const Book = (props: BookProps) => {
                   uid={bookPath + bookChallengeId}
                   progressStorage={progressStorage}
                   isExample={activeNode.isExample}
+                  isAssessment={activeNode.isAssessment}
                   typ={activeNode.typ}
                   onBookUploaded={props.onBookUploaded}
                   authContext={authContext}

--- a/src/book/Book.tsx
+++ b/src/book/Book.tsx
@@ -326,6 +326,7 @@ const Book = (props: BookProps) => {
                 uid={bookPath + bookChallengeId}
                 progressStorage={progressStorage}
                 isExample={activeNode.isExample}
+                isAssessment={activeNode.isAssessment}
                 typ={activeNode.typ}
                 onBookUploaded={props.onBookUploaded}
                 authContext={authContext}

--- a/src/book/components/BookContents.tsx
+++ b/src/book/components/BookContents.tsx
@@ -5,6 +5,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import CancelIcon from "@mui/icons-material/Cancel";
 import DoneIcon from "@mui/icons-material/Done";
+import GradingIcon from "@mui/icons-material/Grading";
 
 import BookNodeModel, { extractIds } from "../../models/BookNodeModel";
 import { AllTestResults } from "../../models/Tests";
@@ -30,7 +31,11 @@ function RecursiveItem({ node, allTestResults }: RecursiveArgs) {
       label={
         <div className="test-state-icon">
           {allTestResults.passed.has(node.id) ? (
-            <DoneIcon color="success"></DoneIcon>
+            node.isAssessment ? (
+              <GradingIcon color="success"></GradingIcon>
+            ) : (
+              <DoneIcon color="success"></DoneIcon>
+            )
           ) : allTestResults.failed.has(node.id) ? (
             <CancelIcon color="error"></CancelIcon>
           ) : null}

--- a/src/book/utils/BookFetcher.ts
+++ b/src/book/utils/BookFetcher.ts
@@ -167,7 +167,8 @@ class BookFetcher implements IBookFetcher {
     mainUrl: string,
     allRes: AllTestResults,
     fileRoot: boolean,
-    authContext?: SessionContextType
+    authContext?: SessionContextType,
+    isAssessment: boolean = false
   ) {
     bookNode.bookMainUrl = mainUrl;
     if (fileRoot) {
@@ -175,9 +176,21 @@ class BookFetcher implements IBookFetcher {
       allRes.passed = new Set([...allRes.passed, ...localRes.passed]);
       allRes.failed = new Set([...allRes.failed, ...localRes.failed]);
     }
+
+    if (isAssessment) {
+      bookNode.isAssessment = true;
+    }
+
     if (bookNode.children) {
       for (const child of bookNode.children) {
-        await this.expandBookLinks(child, mainUrl, allRes, false, authContext);
+        await this.expandBookLinks(
+          child,
+          mainUrl,
+          allRes,
+          false,
+          authContext,
+          isAssessment || bookNode.isAssessment
+        );
       }
     }
     if (bookNode.bookLink) {

--- a/src/challenge/Challenge.tsx
+++ b/src/challenge/Challenge.tsx
@@ -288,6 +288,7 @@ class Challenge
             }
             testResults={this.state.testResults}
             canKill={this.state.editorState === ChallengeStatus.RUNNING}
+            isAssessment={!!this.props.isAssessment}
           />
         </CardContent>
       </Card>

--- a/src/challenge/Challenge.tsx
+++ b/src/challenge/Challenge.tsx
@@ -43,6 +43,7 @@ type ChallengeState = IChallengeState & {
   savedCode: string | null;
   editorFullScreen: boolean;
   testsPassing: boolean | undefined;
+  isSubmitted: boolean;
   helpOpen: boolean;
   guideMinimised: boolean;
   showBookUpload: boolean;
@@ -91,6 +92,8 @@ class Challenge
     100
   );
 
+  submittedCallback = () => this.setState({ isSubmitted: true });
+
   canvasMountedCallback = () => {
     if (this.canvasPromiseResolve) {
       const local = this.canvasPromiseResolve;
@@ -111,6 +114,7 @@ class Challenge
     editorFullScreen: false,
     testResults: [],
     testsPassing: undefined,
+    isSubmitted: false,
     helpOpen: false,
     guideMinimised: false,
     typ: ChallengeTypes.TYP_PY,
@@ -182,6 +186,7 @@ class Challenge
       this.setState({
         testResults: testRes === undefined ? [] : [{ outcome: testRes }],
         testsPassing: testRes,
+        isSubmitted: false,
       });
     }
     if (prevProps.typ !== this.props.typ) {
@@ -264,10 +269,14 @@ class Challenge
             }
             canDebug={this.state.editorState === ChallengeStatus.READY}
             canSubmit={
-              !this.props.isExample &&
-              (this.props.tests !== null || this.props.typ === "parsons")
+              (!this.props.isExample &&
+                (this.props.tests !== null || this.props.typ === "parsons")) ||
+              (this.props.isAssessment !== undefined && this.props.isAssessment)
             }
             testResults={this.state.testResults}
+            isSubmitted={
+              this.props.isAssessment ? this.state.isSubmitted : undefined
+            }
             canKill={this.state.editorState === ChallengeStatus.RUNNING}
           />
         </CardContent>

--- a/src/challenge/Challenge.tsx
+++ b/src/challenge/Challenge.tsx
@@ -43,7 +43,7 @@ type ChallengeState = IChallengeState & {
   savedCode: string | null;
   editorFullScreen: boolean;
   testsPassing: boolean | undefined;
-  isSubmitted: boolean;
+
   helpOpen: boolean;
   guideMinimised: boolean;
   showBookUpload: boolean;
@@ -92,8 +92,6 @@ class Challenge
     100
   );
 
-  submittedCallback = () => this.setState({ isSubmitted: true });
-
   canvasMountedCallback = () => {
     if (this.canvasPromiseResolve) {
       const local = this.canvasPromiseResolve;
@@ -114,7 +112,6 @@ class Challenge
     editorFullScreen: false,
     testResults: [],
     testsPassing: undefined,
-    isSubmitted: false,
     helpOpen: false,
     guideMinimised: false,
     typ: ChallengeTypes.TYP_PY,
@@ -198,7 +195,6 @@ class Challenge
       this.setState({
         testResults: testRes === undefined ? [] : [{ outcome: testRes }],
         testsPassing: testRes,
-        isSubmitted: false,
       });
     }
     if (prevProps.typ !== this.props.typ) {
@@ -288,12 +284,9 @@ class Challenge
             canSubmit={
               (!this.props.isExample &&
                 (this.props.tests !== null || this.props.typ === "parsons")) ||
-              (this.props.isAssessment !== undefined && this.props.isAssessment)
+              !!this.props.isAssessment
             }
             testResults={this.state.testResults}
-            isSubmitted={
-              this.props.isAssessment ? this.state.isSubmitted : undefined
-            }
             canKill={this.state.editorState === ChallengeStatus.RUNNING}
           />
         </CardContent>

--- a/src/challenge/ChallengeContext.ts
+++ b/src/challenge/ChallengeContext.ts
@@ -427,6 +427,12 @@ class ChallengeContextClass {
         let tests = this.challenge.props.tests;
         if (code && tests) {
           this.actions["testpy"](code, tests);
+        } else if (code && this.challenge.props.isAssessment) {
+          this.actions["report-result"](
+            [],
+            code,
+            this.challenge.props.bookNode
+          );
         }
       }
     },
@@ -442,9 +448,12 @@ class ChallengeContextClass {
       if (this.challenge.props.progressStorage) {
         this.challenge.props.progressStorage.setResult(
           bookNode,
-          newTestOutcome,
+          newTestOutcome || this.challenge.props.isAssessment,
           code
         );
+      }
+      if (this.challenge.submittedCallback) {
+        this.challenge.submittedCallback();
       }
     },
     testpy: (code: string, tests: TestCases) => {

--- a/src/challenge/ChallengeContext.ts
+++ b/src/challenge/ChallengeContext.ts
@@ -429,6 +429,9 @@ class ChallengeContextClass {
         let tests = this.challenge.props.tests;
 
         if (code && this.challenge.props.isAssessment) {
+          this.challenge.setState({
+            testResults: [{ outcome: true }],
+          });
           this.actions["report-result"](
             [{ outcome: true }],
             code,
@@ -451,7 +454,7 @@ class ChallengeContextClass {
       if (this.challenge.props.progressStorage) {
         this.challenge.props.progressStorage.setResult(
           bookNode,
-          newTestOutcome || this.challenge.props.isAssessment,
+          newTestOutcome,
           code
         );
       }

--- a/src/challenge/ChallengeContext.ts
+++ b/src/challenge/ChallengeContext.ts
@@ -427,14 +427,15 @@ class ChallengeContextClass {
       } else {
         let code = this.challenge.editorRef.current?.getValue();
         let tests = this.challenge.props.tests;
-        if (code && tests) {
-          this.actions["testpy"](code, tests);
-        } else if (code && this.challenge.props.isAssessment) {
+
+        if (code && this.challenge.props.isAssessment) {
           this.actions["report-result"](
-            [],
+            [{ outcome: true }],
             code,
             this.challenge.props.bookNode
           );
+        } else if (code && tests) {
+          this.actions["testpy"](code, tests);
         }
       }
     },
@@ -453,9 +454,6 @@ class ChallengeContextClass {
           newTestOutcome || this.challenge.props.isAssessment,
           code
         );
-      }
-      if (this.challenge.submittedCallback) {
-        this.challenge.submittedCallback();
       }
     },
     testpy: (code: string, tests: TestCases) => {

--- a/src/challenge/ChallengeEditor.tsx
+++ b/src/challenge/ChallengeEditor.tsx
@@ -146,6 +146,7 @@ class ChallengeEditor
     let proxy = {
       name: node.name,
       isExample: node.isExample,
+      isAssessment: node.isAssessment,
       typ: node.typ,
       tests: node.tests,
       additionalFiles: node.additionalFiles,
@@ -331,6 +332,10 @@ class ChallengeEditor
     if (editedNode.isExample !== this.props.bookNode.isExample) {
       changed = true;
       this.props.bookNode.isExample = editedNode.isExample;
+    }
+    if (editedNode.isAssessment !== this.props.bookNode.isAssessment) {
+      changed = true;
+      this.props.bookNode.isAssessment = editedNode.isAssessment;
     }
     if (editedNode.typ !== this.props.bookNode.typ) {
       changed = true;

--- a/src/challenge/ChallengeEditor.tsx
+++ b/src/challenge/ChallengeEditor.tsx
@@ -453,6 +453,7 @@ class ChallengeEditor
             canSubmit={false}
             testResults={[]}
             canKill={this.state.editorState === ChallengeStatus.RUNNING}
+            isAssessment={!!this.props.isAssessment}
           />
         </CardContent>
       </Card>

--- a/src/challenge/IChallenge.ts
+++ b/src/challenge/IChallenge.ts
@@ -59,7 +59,6 @@ interface IChallenge {
   keyDownBuffer: Uint8Array | null;
 
   printCallback: DebouncedFunc<() => void>;
-  submittedCallback?: () => void;
   canvasMountedCallback: () => void;
   canvasPromiseResolve?: (value: any) => void;
 

--- a/src/challenge/IChallenge.ts
+++ b/src/challenge/IChallenge.ts
@@ -22,6 +22,7 @@ type IChallengeProps = {
   uid: string;
   tests?: TestCases | null;
   isExample?: boolean;
+  isAssessment?: boolean;
   guidePath: string;
   codePath: string;
   fetcher: IBookFetcher;
@@ -57,6 +58,7 @@ interface IChallenge {
   keyDownBuffer: Uint8Array | null;
 
   printCallback: DebouncedFunc<() => void>;
+  submittedCallback?: () => void;
   canvasMountedCallback: () => void;
   canvasPromiseResolve?: (value: any) => void;
 

--- a/src/challenge/components/MainControls.tsx
+++ b/src/challenge/components/MainControls.tsx
@@ -11,6 +11,7 @@ type MainControlsProps = {
   canRunOnly: boolean;
   canSubmit: boolean;
   testResults: TestResults;
+  isAssessment: boolean;
   guideMinimised: boolean;
   canKill: boolean;
   onGuideDisplayToggle: () => void;
@@ -81,7 +82,10 @@ const MainControlsStack = (props: MainControlsProps) => {
         </Button>
       </Box>
 
-      <TestResultsIndicator testResults={props.testResults} />
+      <TestResultsIndicator
+        testResults={props.testResults}
+        isAssessment={props.isAssessment}
+      />
     </Stack>
   );
 };
@@ -110,7 +114,10 @@ const MainControlsGrid = (props: MainControlsProps) => {
               </Button>
             </Box>
           ) : null}
-          <TestResultsIndicator testResults={props.testResults} />
+          <TestResultsIndicator
+            testResults={props.testResults}
+            isAssessment={props.isAssessment}
+          />
         </Stack>
       </Grid>
       <Grid item>

--- a/src/challenge/components/MainControls.tsx
+++ b/src/challenge/components/MainControls.tsx
@@ -10,6 +10,7 @@ type MainControlsProps = {
   canDebug: boolean;
   canSubmit: boolean;
   testResults: TestResults;
+  isSubmitted?: boolean;
   guideMinimised: boolean;
   canKill: boolean;
   onGuideDisplayToggle: () => void;
@@ -78,7 +79,10 @@ const MainControlsStack = (props: MainControlsProps) => {
         </Button>
       </Box>
 
-      <TestResultsIndicator testResults={props.testResults} />
+      <TestResultsIndicator
+        testResults={props.testResults}
+        isSubmitted={props.isSubmitted}
+      />
     </Stack>
   );
 };
@@ -104,7 +108,10 @@ const MainControlsGrid = (props: MainControlsProps) => {
               </Button>
             </Box>
           ) : null}
-          <TestResultsIndicator testResults={props.testResults} />
+          <TestResultsIndicator
+            testResults={props.testResults}
+            isSubmitted={props.isSubmitted}
+          />
         </Stack>
       </Grid>
       <Grid item>

--- a/src/challenge/components/MainControls.tsx
+++ b/src/challenge/components/MainControls.tsx
@@ -11,7 +11,6 @@ type MainControlsProps = {
   canRunOnly: boolean;
   canSubmit: boolean;
   testResults: TestResults;
-  isSubmitted?: boolean;
   guideMinimised: boolean;
   canKill: boolean;
   onGuideDisplayToggle: () => void;
@@ -82,10 +81,7 @@ const MainControlsStack = (props: MainControlsProps) => {
         </Button>
       </Box>
 
-      <TestResultsIndicator
-        testResults={props.testResults}
-        isSubmitted={props.isSubmitted}
-      />
+      <TestResultsIndicator testResults={props.testResults} />
     </Stack>
   );
 };
@@ -114,10 +110,7 @@ const MainControlsGrid = (props: MainControlsProps) => {
               </Button>
             </Box>
           ) : null}
-          <TestResultsIndicator
-            testResults={props.testResults}
-            isSubmitted={props.isSubmitted}
-          />
+          <TestResultsIndicator testResults={props.testResults} />
         </Stack>
       </Grid>
       <Grid item>

--- a/src/components/TestResultIndicator.tsx
+++ b/src/components/TestResultIndicator.tsx
@@ -13,10 +13,12 @@ import { TooltipProps, tooltipClasses } from "@mui/material/Tooltip";
 import { styled } from "@mui/material/styles";
 import CancelIcon from "@mui/icons-material/Cancel";
 import DoneIcon from "@mui/icons-material/Done";
+import GradingIcon from "@mui/icons-material/Grading";
 import { TestResults, TestResult } from "../models/Tests";
 
 type TestResultsIndicatorProps = {
   testResults: TestResults;
+  isAssessment: boolean;
 };
 
 const HtmlTooltip = styled(({ className, ...props }: TooltipProps) => (
@@ -145,6 +147,21 @@ const TestResultsIndicator = (props: TestResultsIndicatorProps) => {
   }
 
   if (allPassing) {
+    if (props.isAssessment) {
+      return (
+        <HtmlTooltip title="Submitted for manual marking">
+          <GradingIcon
+            style={{
+              display: "inline-block",
+              verticalAlign: "middle",
+              height: "100%",
+            }}
+            color="success"
+            fontSize="large"
+          />
+        </HtmlTooltip>
+      );
+    }
     return (
       <DoneIcon
         style={{

--- a/src/components/TestResultIndicator.tsx
+++ b/src/components/TestResultIndicator.tsx
@@ -17,6 +17,7 @@ import { TestResults, TestResult } from "../models/Tests";
 
 type TestResultsIndicatorProps = {
   testResults: TestResults;
+  isSubmitted?: boolean;
 };
 
 const HtmlTooltip = styled(({ className, ...props }: TooltipProps) => (
@@ -132,11 +133,17 @@ const TestResultsIndicator = (props: TestResultsIndicatorProps) => {
   const [allPassing, setAllPassing] = useState<boolean | null>(null);
   useEffect(
     () =>
-      setAllPassing(props.testResults.filter((x) => !x.outcome).length === 0),
-    [props.testResults]
+      setAllPassing(
+        props.testResults.filter((x) => !x.outcome).length === 0 ||
+          (props.isSubmitted !== undefined && props.isSubmitted)
+      ),
+    [props.testResults, props.isSubmitted]
   );
 
-  if (props.testResults.length < 1) {
+  if (
+    (props.testResults.length < 1 && props.isSubmitted === undefined) ||
+    (props.isSubmitted !== undefined && !props.isSubmitted)
+  ) {
     return <span></span>;
   }
 

--- a/src/components/TestResultIndicator.tsx
+++ b/src/components/TestResultIndicator.tsx
@@ -17,7 +17,6 @@ import { TestResults, TestResult } from "../models/Tests";
 
 type TestResultsIndicatorProps = {
   testResults: TestResults;
-  isSubmitted?: boolean;
 };
 
 const HtmlTooltip = styled(({ className, ...props }: TooltipProps) => (
@@ -137,17 +136,11 @@ const TestResultsIndicator = (props: TestResultsIndicatorProps) => {
   const [allPassing, setAllPassing] = useState<boolean | null>(null);
   useEffect(
     () =>
-      setAllPassing(
-        props.testResults.filter((x) => !x.outcome).length === 0 ||
-          (props.isSubmitted !== undefined && props.isSubmitted)
-      ),
-    [props.testResults, props.isSubmitted]
+      setAllPassing(props.testResults.filter((x) => !x.outcome).length === 0),
+    [props.testResults]
   );
 
-  if (
-    (props.testResults.length < 1 && props.isSubmitted === undefined) ||
-    (props.isSubmitted !== undefined && !props.isSubmitted)
-  ) {
+  if (props.testResults.length < 1) {
     return <span></span>;
   }
 

--- a/src/models/BookNodeModel.ts
+++ b/src/models/BookNodeModel.ts
@@ -11,6 +11,7 @@ type BookNodeModel = {
   additionalFiles?: AdditionalFiles;
   bookLink?: string;
   isExample?: boolean;
+  isAssessment?: boolean;
   typ?: "py" | "parsons" | "canvas";
 
   // cached


### PR DESCRIPTION
Can be set on top level book node and is inherited by all children or can be set on child.

If set then submit allows code to be stored on backend, with empty test cases, and shows tick to notify of successful submission rather than successful result (which would be marked ourselves later after we'd downloaded the code)