### PR TITLE
Reizes to give terminal more size at runtime

### DIFF
--- a/src/challenge/Challenge.tsx
+++ b/src/challenge/Challenge.tsx
@@ -120,6 +120,8 @@ class Challenge
     showBookUpload: false,
     additionalFilesLoaded: {},
     turtleExampleRendered: undefined,
+    paneSizes: [700, 300],
+    renderKey: 0,
   };
 
   constructor(props: ChallengeProps) {
@@ -232,6 +234,13 @@ class Challenge
       : visible;
   };
 
+  changeSizeAtRuntime = () => {
+    this.setState((prevState) => ({
+      paneSizes: [300, 700],
+      renderKey: prevState.renderKey + 1, // Increment render key to trigger refresh
+    }));
+  };
+
   renderEditor() {
     if (this.props.typ === "parsons") {
       return (
@@ -289,6 +298,7 @@ class Challenge
             testResults={this.state.testResults}
             canKill={this.state.editorState === ChallengeStatus.RUNNING}
             isAssessment={!!this.props.isAssessment}
+            onRunning={this.changeSizeAtRuntime}
           />
         </CardContent>
       </Card>
@@ -383,7 +393,11 @@ class Challenge
 
               <Allotment className="h-100" defaultSizes={[650, 350]}>
                 <Allotment.Pane>
-                  <Allotment vertical defaultSizes={[650, 350]}>
+                  <Allotment
+                    vertical
+                    defaultSizes={this.state.paneSizes}
+                    key={`allotment_${this.state.renderKey}`}
+                  >
                     <Allotment.Pane>{this.renderEditor()}</Allotment.Pane>
                     <Allotment.Pane
                       visible={this.getVisibilityWithHack(

--- a/src/challenge/ChallengeEditor.tsx
+++ b/src/challenge/ChallengeEditor.tsx
@@ -133,6 +133,8 @@ class ChallengeEditor
     saveDialogProps: undefined,
     additionalFilesLoaded: {},
     turtleExampleRendered: undefined,
+    paneSizes: [700, 300],
+    renderKey: 0,
   };
 
   constructor(props: ChallengeEditorProps) {
@@ -394,6 +396,13 @@ class ChallengeEditor
       : visible;
   };
 
+  changeSizeAtRuntime = () => {
+    this.setState((prevState) => ({
+      paneSizes: [300, 700],
+      renderKey: prevState.renderKey + 1, // Increment render key to trigger refresh
+    }));
+  };
+
   getDisplayFiles = () => {
     const files = (this.props.bookNode.additionalFiles || []).map(
       (file) => file.filename
@@ -454,6 +463,7 @@ class ChallengeEditor
             testResults={[]}
             canKill={this.state.editorState === ChallengeStatus.RUNNING}
             isAssessment={!!this.props.isAssessment}
+            onRunning={this.changeSizeAtRuntime}
           />
         </CardContent>
       </Card>
@@ -534,7 +544,11 @@ class ChallengeEditor
 
             <Allotment className="h-100" defaultSizes={[650, 350]}>
               <Allotment.Pane>
-                <Allotment vertical defaultSizes={[650, 350]}>
+                <Allotment
+                  vertical
+                  defaultSizes={this.state.paneSizes}
+                  key={`allotment_${this.state.renderKey}`}
+                >
                   <Allotment.Pane>
                     <PyEditor
                       ref={this.editorRef}

--- a/src/challenge/IChallenge.ts
+++ b/src/challenge/IChallenge.ts
@@ -44,6 +44,8 @@ type IChallengeState = {
   testResults: TestResults;
   additionalFilesLoaded: AdditionalFilesContents;
   turtleExampleRendered: string | undefined;
+  paneSizes: number[];
+  renderKey: number; // Initial render key used for resetting the allotment pane sizes
 };
 
 interface IChallenge {

--- a/src/challenge/components/MainControls.tsx
+++ b/src/challenge/components/MainControls.tsx
@@ -15,6 +15,7 @@ type MainControlsProps = {
   guideMinimised: boolean;
   canKill: boolean;
   onGuideDisplayToggle: () => void;
+  onRunning: () => void;
 };
 
 const MainControlsStack = (props: MainControlsProps) => {
@@ -42,7 +43,10 @@ const MainControlsStack = (props: MainControlsProps) => {
             variant="contained"
             color="primary"
             disabled={!props.canDebug}
-            onClick={() => challengeContext?.actions["debug"]()}
+            onClick={() => {
+              props.onRunning();
+              challengeContext?.actions["debug"]();
+            }}
           >
             DEBUG
           </Button>
@@ -53,7 +57,10 @@ const MainControlsStack = (props: MainControlsProps) => {
           variant="contained"
           color="primary"
           disabled={!props.canDebug}
-          onClick={() => challengeContext?.actions["debug"]("run")}
+          onClick={() => {
+            props.onRunning();
+            challengeContext?.actions["debug"]("run");
+          }}
         >
           RUN
         </Button>
@@ -64,7 +71,10 @@ const MainControlsStack = (props: MainControlsProps) => {
             variant="contained"
             color="primary"
             disabled={!props.canDebug}
-            onClick={() => challengeContext?.actions["test"]()}
+            onClick={() => {
+              props.onRunning();
+              challengeContext?.actions["test"]();
+            }}
           >
             Submit
           </Button>
@@ -100,6 +110,7 @@ const MainControlsGrid = (props: MainControlsProps) => {
             <RunSplitButton
               disabled={!props.canDebug}
               canRunOnly={props.canRunOnly}
+              onRunning={props.onRunning}
             />
           </Box>
           {props.canSubmit ? (
@@ -108,7 +119,10 @@ const MainControlsGrid = (props: MainControlsProps) => {
                 variant="contained"
                 color="primary"
                 disabled={!props.canDebug}
-                onClick={() => challengeContext?.actions["test"]()}
+                onClick={() => {
+                  props.onRunning();
+                  challengeContext?.actions["test"]();
+                }}
               >
                 Submit
               </Button>

--- a/src/challenge/components/RunSplitButton.tsx
+++ b/src/challenge/components/RunSplitButton.tsx
@@ -14,6 +14,7 @@ import Box from "@mui/material/Box";
 type RunSplitButtonProps = {
   disabled: boolean;
   canRunOnly: boolean;
+  onRunning: () => void;
 };
 
 const options = ["DEBUG", "RUN"];
@@ -27,6 +28,7 @@ export default function RunSplitButton(props: RunSplitButtonProps) {
 
   const handleClick = () => {
     let mode: "debug" | "run" = selectedIndex === 0 ? "debug" : "run";
+    props.onRunning();
     challengeContext?.actions["debug"](mode);
   };
 


### PR DESCRIPTION
If this is reasonable in principle (with the overload of triggering the allotment re-renders by increasing the renderKey) then we could remember the current allotment sizes into state potentially to restore it to that after the runtime ends?

Iain was asking for auto terminal size extending at runtime so first experiment to this end ... but then post runtime could either automatically restore back to 700/300 or could try to remember user's current size in case manually resized. Also this uses an incrementing renderKey to force the allotment panes to refresh each run time... is this reasonable overload?