### PR TITLE
Reduce loading race conditions

### DIFF
--- a/src/challenge/Challenge.tsx
+++ b/src/challenge/Challenge.tsx
@@ -170,6 +170,8 @@ const Challenge = (props: ChallengeProps) => {
     starterCode,
     additionalFilesLoaded,
     forceReload,
+    isLoadingGuide,
+    isLoadingCode,
   } = useChallengeLoader({
     fetcher: props.fetcher,
     guidePath: props.guidePath,
@@ -532,6 +534,7 @@ const Challenge = (props: ChallengeProps) => {
                         setEditorFullScreen((x) => !x);
                       }}
                       codeRunner={codeRunner}
+                      isLoading={isLoadingCode}
                     />
                   </Allotment.Pane>
                   <Allotment.Pane
@@ -595,6 +598,7 @@ const Challenge = (props: ChallengeProps) => {
                         turtleExampleImage={turtleExampleRendered}
                         isEditing={isEditingGuide}
                         comment={comment}
+                        isLoading={isLoadingGuide}
                       />
                     )}
                     <BookControlFabs

--- a/src/challenge/components/Editors/MainEditor.tsx
+++ b/src/challenge/components/Editors/MainEditor.tsx
@@ -17,6 +17,7 @@ type MainEditorProps = {
   pyEditorRef: React.RefObject<PyEditorHandle>;
   codeRunner: CodeRunnerRef;
   onToggleFullScreen: () => void;
+  isLoading?: boolean;
 };
 
 const MainEditor = (props: MainEditorProps) => {
@@ -43,6 +44,7 @@ const MainEditor = (props: MainEditorProps) => {
       isOnBreakPoint={props.codeRunner.state === CodeRunnerState.ON_BREAKPOINT}
       debugContext={props.codeRunner.debugContext || emptyDebugContext}
       onToggleFullScreen={props.onToggleFullScreen}
+      isLoading={props.isLoading}
     />
   );
 };

--- a/src/challenge/components/Editors/PyEditor.css
+++ b/src/challenge/components/Editors/PyEditor.css
@@ -21,5 +21,5 @@
   width: 100% !important;
   height: 100% !important;
   z-index: 1000;
-  background-color: rgba(0, 0, 0, 0.1) !important;
+  background-color: rgba(0, 0, 0, 0.05) !important;
 }

--- a/src/challenge/components/Editors/PyEditor.css
+++ b/src/challenge/components/Editors/PyEditor.css
@@ -15,3 +15,11 @@
 .theme-vs-light .breakpoint-hit {
   background-color: rgba(252, 252, 122, 0.623);
 }
+
+.py-loader-backdrop {
+  position: absolute !important;
+  width: 100% !important;
+  height: 100% !important;
+  z-index: 1000;
+  background-color: rgba(0, 0, 0, 0.1) !important;
+}

--- a/src/challenge/components/Editors/PyEditor.tsx
+++ b/src/challenge/components/Editors/PyEditor.tsx
@@ -13,7 +13,7 @@ import DebugContext from "../../../coderunner/DebugContext";
 
 import ChallengeContext from "../../ChallengeContext";
 import VsThemeContext from "../../../themes/VsThemeContext";
-import { Backdrop, CircularProgress, makeStyles } from "@mui/material";
+import { Backdrop, CircularProgress } from "@mui/material";
 
 const STANDALONE_BUILD = false;
 if (STANDALONE_BUILD) {

--- a/src/challenge/components/Editors/PyEditor.tsx
+++ b/src/challenge/components/Editors/PyEditor.tsx
@@ -13,6 +13,7 @@ import DebugContext from "../../../coderunner/DebugContext";
 
 import ChallengeContext from "../../ChallengeContext";
 import VsThemeContext from "../../../themes/VsThemeContext";
+import { Backdrop, CircularProgress, makeStyles } from "@mui/material";
 
 const STANDALONE_BUILD = false;
 if (STANDALONE_BUILD) {
@@ -29,6 +30,7 @@ type PyEditorProps = {
   debugContext: DebugContext;
   height?: string | undefined;
   onToggleFullScreen: () => void;
+  isLoading?: boolean;
 };
 
 type PyEditorHandle = {
@@ -370,6 +372,13 @@ const PyEditor = React.forwardRef<PyEditorHandle, PyEditorProps>(
           }}
           onChange={handleEditorChange}
         />
+        <Backdrop
+          open={!!props.isLoading}
+          className="py-loader-backdrop"
+          transitionDuration={500}
+        >
+          <CircularProgress color="inherit" />
+        </Backdrop>
         <a
           className="hidden"
           download="code.py"

--- a/src/challenge/components/Guide/ChallengeGuide.tsx
+++ b/src/challenge/components/Guide/ChallengeGuide.tsx
@@ -6,7 +6,7 @@ import React, {
 } from "react";
 import ChallengeContext from "../../ChallengeContext";
 import Guide from "../../../components/Guide";
-import { Paper, TextField } from "@mui/material";
+import { Fade, Paper, Skeleton, TextField, Typography } from "@mui/material";
 
 type ChallengeGuideProps = {
   initialMd: string;
@@ -15,6 +15,7 @@ type ChallengeGuideProps = {
   comment?: string;
 
   isEditing?: boolean;
+  isLoading?: boolean;
 };
 
 type ChallengeGuideRef = {
@@ -46,6 +47,20 @@ const ChallengeGuide = React.forwardRef<ChallengeGuideRef, ChallengeGuideProps>(
           InputProps={{ disableUnderline: true }}
           sx={{ width: "100%", height: "100%", overflowY: "auto" }}
         />
+      );
+    }
+    if (props.isLoading) {
+      return (
+        <Fade in={props.isLoading} timeout={500}>
+          <div>
+            <Typography variant="h3">
+              <Skeleton />
+            </Typography>
+            <Skeleton />
+            <Skeleton />
+            <Skeleton />
+          </div>
+        </Fade>
       );
     }
     return (


### PR DESCRIPTION
## Current issue
If students navigate quickly e.g. visiting 2 or more challenges within the server response time, the challenge loader might return any of these (not necessarily the last one or the correct one). Worse than that, the code and the guide can get out of synch.

## Fix
In the challenge loader, check at the fetch return whether we are still on the same challenge (reference the current active guideMD and code paths against the returned ones).
Also, display a loader skeleton / backdrop while a challenge is loading, so if the server is rather slow, students still understand what's happening.
![image](https://github.com/user-attachments/assets/78327f0b-65e5-4e38-ac1f-7dfb9a4a10c5)
