### PR TITLE
fix ui bug and improve edit/clone infrastructure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "python-sponge",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "python-sponge",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "dependencies": {
         "@azure/msal-react": "^3.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "python-sponge",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "type": "module",
   "description": "Client-side framework for learning Python and authoring Python challenges",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { useEffect, useState, lazy, Suspense } from "react";
 import Book from "./book/Book";
 import FolderPicker from "./components/FolderPicker";
 import packageJson from "../package.json";
+import { BookUploadType } from "./book/components/BookUpload";
 
 const AdminWrapper = lazy(() => import("./auth/AdminWrapper"));
 const AllClasses = lazy(() => import("./teacher/AllClasses"));
@@ -37,17 +38,31 @@ const AppContainer = () => {
   >();
   const navigate = useNavigate();
 
-  const openBookFromZip = (file: File, edit: boolean) => {
+  const openBookFromZip = (file: File, openType: BookUploadType) => {
     setBookFile(file);
+    let editParam = "";
+    if (openType === "editing") {
+      editParam = "open-edit";
+    } else if (openType === "cloning") {
+      editParam = "clone";
+    }
     navigate({
       pathname: "/",
-      search: `?bk=book.json${edit ? "&edit=clone" : ""}`,
+      search: `?bk=book.json${editParam ? "&edit=" + editParam : ""}`,
     });
   };
 
-  const openLocalFolder = (folder: FileSystemDirectoryHandle) => {
+  const openLocalFolder = (
+    folder: FileSystemDirectoryHandle,
+    isForEditing: boolean
+  ) => {
     setLocalFolder(folder);
-    navigate({ pathname: "/", search: "?bk=book.json&edit=localpreview" });
+    navigate({
+      pathname: "/",
+      search: `?bk=book.json${
+        isForEditing ? "&edit=open-edit" : "&edit=localpreview"
+      }`,
+    });
   };
 
   useEffect(() => {
@@ -75,7 +90,10 @@ const AppContainer = () => {
           isForEditing={isTeacher?.length > 0}
           onBookUploaded={openBookFromZip}
         />
-        <FolderPicker onFolderPicked={openLocalFolder} />
+        <FolderPicker
+          isForEditing={isTeacher?.length > 0}
+          onFolderPicked={openLocalFolder}
+        />
       </>
     );
   }

--- a/src/StartPage.tsx
+++ b/src/StartPage.tsx
@@ -52,14 +52,20 @@ const StartPage = () => {
           <a href="/?coop=1">/</a>
         </p>
         <h3>For content creators</h3>
-        To clone a book for editing, you can just append <code>
-          clone=true
-        </code>{" "}
-        in the query path. E.g.:
+        When you have a book open in the borwser, you can open it for editing by
+        appending <code>edit=open-edit</code> in the query path. E.g.:
+        <a href="/?bk=.%2Fexamples%2Fbook.json&edit=open-edit">
+          ?bk=.%2Fexamples%2Fbook.json&edit=open-edit
+        </a>
+        . This will open the book for editing. <br />
+        If you want to fork the book, it is best practice to spawn new ids for
+        the challenges. For this, just append <code>clone=true</code> in the
+        query path. E.g.:
         <a href="/?bk=.%2Fexamples%2Fbook.json&chid=afb57340-1197-473c-b24d-5687796fd3d4&edit=clone">
           ?bk=.%2Fexamples%2Fbook.json&chid=afb57340-1197-473c-b24d-5687796fd3d4&edit=clone
         </a>
-        .
+        . This will opend the book for editing, spawning new ids for each
+        challenge.
         <p>
           Or you can upload the zip file as well to the landing page{" "}
           <a href="/?teacher=true&coop=1">/?teacher=true&coop=1</a>

--- a/src/book/Book.tsx
+++ b/src/book/Book.tsx
@@ -26,11 +26,12 @@ import SessionContext from "../auth/contexts/SessionContext";
 import { ProgressStorage, useProgressStorage } from "./utils/ProgressStorage";
 import GuideOnlyChallenge from "../challenge/GuideOnlyChallenge";
 import Challenge from "../challenge/Challenge";
+import { BookUploadType } from "./components/BookUpload";
 
 type BookProps = {
   zipFile?: File;
   localFolder?: FileSystemDirectoryHandle;
-  onBookUploaded: (file: File, edit: boolean) => void;
+  onBookUploaded: (file: File, uploadType: BookUploadType) => void;
 };
 
 type PathsState = {
@@ -134,15 +135,18 @@ const Book = (props: BookProps) => {
     () => (store: EditableBookStore) => {
       setEditableBookStore(store);
       setEditState("editing");
-      navigate({
-        search:
-          "?" +
-          new URLSearchParams({
-            bk: "edit://edit/book.json",
-            chid: activeNode?.id || "",
-            edit: "editing",
-          }),
-      });
+      navigate(
+        {
+          search:
+            "?" +
+            new URLSearchParams({
+              bk: "edit://edit/book.json",
+              chid: activeNode?.id || "",
+              edit: "editing",
+            }),
+        },
+        { replace: true }
+      );
     },
     [activeNode, navigate]
   );
@@ -155,7 +159,20 @@ const Book = (props: BookProps) => {
       bookFetcher instanceof BookFetcher
     ) {
       setEditState("cloning");
-      createEditableBookStore(rootNode, bookFetcher, authContext).then(
+      createEditableBookStore(rootNode, bookFetcher, authContext, true).then(
+        bookClonedForEditing
+      );
+      return;
+    }
+    if (
+      editParam === "open-edit" &&
+      !editState &&
+      rootNode &&
+      bookFetcher &&
+      bookFetcher instanceof BookFetcher
+    ) {
+      setEditState("cloning");
+      createEditableBookStore(rootNode, bookFetcher, authContext, false).then(
         bookClonedForEditing
       );
       return;

--- a/src/book/components/BookUpload.tsx
+++ b/src/book/components/BookUpload.tsx
@@ -1,11 +1,20 @@
 import { useMemo, useState, useEffect } from "react";
 import { useDropzone } from "react-dropzone";
-import { Button, Card, CardContent, CardActions, Box } from "@mui/material";
+import {
+  Button,
+  Card,
+  CardContent,
+  CardActions,
+  Box,
+  Tooltip,
+} from "@mui/material";
 import { useTheme } from "@mui/material/styles";
+
+export type BookUploadType = "reading" | "cloning" | "editing";
 
 type BookUploadProps = {
   isForEditing?: boolean;
-  onBookUploaded: (zip: File, forEdit: boolean) => void;
+  onBookUploaded: (zip: File, uploadType: BookUploadType) => void;
 };
 
 const baseStyle = {
@@ -59,9 +68,21 @@ const BookUpload = (props: BookUploadProps) => {
     [isFocused, focusedStyle, file, theme]
   );
 
-  const uploadClicked = () => {
+  const handleUploadForReading = () => {
     if (file) {
-      props.onBookUploaded(file, props.isForEditing || false);
+      props.onBookUploaded(file, "reading");
+    }
+  };
+
+  const handleUploadForCloning = () => {
+    if (file) {
+      props.onBookUploaded(file, "cloning");
+    }
+  };
+
+  const handleUploadForEditing = () => {
+    if (file) {
+      props.onBookUploaded(file, "editing");
     }
   };
 
@@ -80,9 +101,24 @@ const BookUpload = (props: BookUploadProps) => {
         <p>File:{file ? file.name : undefined}</p>
       </CardContent>
       <CardActions>
-        <Button onClick={uploadClicked} disabled={!file}>
-          {props.isForEditing ? "Clone" : "Load"}
-        </Button>
+        {!props.isForEditing ? (
+          <Button onClick={handleUploadForReading} disabled={!file}>
+            Load
+          </Button>
+        ) : (
+          <>
+            <Tooltip title="Edit the uploaded book in the browser. Challenge Ids will be kept.">
+              <Button onClick={handleUploadForEditing} disabled={!file}>
+                Edit
+              </Button>
+            </Tooltip>
+            <Tooltip title="Clone to fork the uploaded book and edit it in the browser. Challenge Ids will be changed.">
+              <Button onClick={handleUploadForCloning} disabled={!file}>
+                Clone
+              </Button>
+            </Tooltip>
+          </>
+        )}
         <Button color="error" disabled={!file} onClick={() => setFile(null)}>
           Cancel
         </Button>

--- a/src/book/components/BookUploadModal.tsx
+++ b/src/book/components/BookUploadModal.tsx
@@ -1,9 +1,9 @@
 import { Dialog, DialogContent, DialogTitle } from "@mui/material";
-import BookUpload from "./BookUpload";
+import BookUpload, { BookUploadType } from "./BookUpload";
 
 type BookUploadModalProps = {
   visible: boolean;
-  onBookUploaded: (file: File, edit: boolean) => void;
+  onBookUploaded: (file: File, uploadType: BookUploadType) => void;
   onClose: () => void;
 };
 

--- a/src/book/utils/EditableBookStore.ts
+++ b/src/book/utils/EditableBookStore.ts
@@ -9,9 +9,10 @@ import { SessionContextType } from "../../auth/contexts/SessionContext";
 async function addNode(
   node: BookNodeModel,
   fetcher: BookFetcher,
-  authContext: SessionContextType
+  authContext: SessionContextType,
+  cloneWithNewIds: boolean
 ) {
-  node.id = uuidv4(); // update UUID so this becomes a unique book
+  node.id = cloneWithNewIds ? uuidv4() : node.id; // update UUID so this becomes a unique book
   if (node.guide) {
     let absPath = absolutisePath(
       node.guide,
@@ -70,7 +71,7 @@ async function addNode(
 
   if (node.children) {
     for (let child of node.children) {
-      await addNode(child, fetcher, authContext);
+      await addNode(child, fetcher, authContext, cloneWithNewIds);
     }
   }
   node.bookMainUrl = "edit://edit/book.json";
@@ -80,9 +81,10 @@ async function addNode(
 async function createEditableBookStore(
   book: BookNodeModel,
   originalFetcher: BookFetcher,
-  authContext: SessionContextType
+  authContext: SessionContextType,
+  cloneWithNewIds: boolean
 ) {
-  await addNode(book, originalFetcher, authContext);
+  await addNode(book, originalFetcher, authContext, cloneWithNewIds);
   localStorage.setItem("edit://edit/book.json", JSON.stringify(book));
   return new EditableBookStore(book);
 }

--- a/src/challenge/Challenge.tsx
+++ b/src/challenge/Challenge.tsx
@@ -42,6 +42,7 @@ import NotificationsContext from "../components/NotificationsContext";
 import { SessionFile } from "../models/SessionFile";
 
 import { GuideToggleFab } from "./components/GuideToggleFab";
+import { BookUploadType } from "../book/components/BookUpload";
 
 type ChallengeProps = {
   uid: string;
@@ -54,7 +55,7 @@ type ChallengeProps = {
   openBookDrawer?: (open: boolean) => void;
   onRequestPreviousChallenge?: () => void;
   onRequestNextChallenge?: () => void;
-  onBookUploaded?: (file: File, edit: boolean) => void;
+  onBookUploaded?: (file: File, uploadType: BookUploadType) => void;
   canReloadBook?: boolean;
   onBookReloadRequested: () => void;
 

--- a/src/components/FolderPicker.tsx
+++ b/src/components/FolderPicker.tsx
@@ -1,23 +1,37 @@
-import { Button, Card, CardActions, CardContent } from "@mui/material";
+import { Button, Card, CardActions, CardContent, Tooltip } from "@mui/material";
 import { Box } from "@mui/system";
 import { useState } from "react";
 
 type FolderPickerProps = {
-  onFolderPicked: (folder: FileSystemDirectoryHandle) => void;
+  onFolderPicked: (
+    folder: FileSystemDirectoryHandle,
+    isForEditing: boolean
+  ) => void;
+  isForEditing?: boolean;
 };
 
 const FolderPicker = (props: FolderPickerProps) => {
   const [folder, setFolder] = useState<FileSystemDirectoryHandle | undefined>();
+  const [selectedEditing, setSelectedEditing] = useState(
+    props.isForEditing || false
+  );
 
-  const selectClicked = () => {
-    window.showDirectoryPicker().then((v) => setFolder(v));
+  const selectClicked = (isForEditing: boolean) => {
+    window
+      .showDirectoryPicker({
+        mode: isForEditing ? "readwrite" : "read",
+      })
+      .then((v) => {
+        setFolder(v);
+        setSelectedEditing(isForEditing);
+      });
   };
 
-  const openClicked = () => {
+  const openClicked = (isForEditing: boolean) => {
     if (!folder) {
       return;
     }
-    props.onFolderPicked(folder);
+    props.onFolderPicked(folder, isForEditing);
   };
 
   return (
@@ -25,17 +39,30 @@ const FolderPicker = (props: FolderPickerProps) => {
       <Box>
         <CardContent>
           {folder
-            ? folder.name
+            ? folder.name + (selectedEditing ? " (selected for editing)" : "")
             : "Pick a folder on your computer with a book.json file in it"}
         </CardContent>
       </Box>
       <CardActions>
-        <Button onClick={() => selectClicked()}>
-          {folder ? "Change" : "Select"}
-        </Button>
-        <Button onClick={() => openClicked()} disabled={!folder}>
-          Open
-        </Button>
+        {folder ? (
+          <>
+            <Button onClick={() => openClicked(selectedEditing)}>Open</Button>
+            <Button color="error" onClick={() => setFolder(undefined)}>
+              Cancel
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button onClick={() => selectClicked(false)}>
+              {props.isForEditing ? "Preview" : "Open"}
+            </Button>
+            {props.isForEditing ? (
+              <Tooltip title="Edit the uploaded book in the browser. Note that changes will not be written back to the folder yet, but you can download the modified book as a zip. Challenge Ids will be kept.">
+                <Button onClick={() => selectClicked(true)}>Edit</Button>
+              </Tooltip>
+            ) : null}
+          </>
+        )}
       </CardActions>
     </Card>
   );

--- a/src/components/Guide.tsx
+++ b/src/components/Guide.tsx
@@ -75,6 +75,20 @@ const Guide = ({ md, turtleExampleImage, challengeId }: GuideProps) => {
     return (
       <StyledGuide>
         <Box>
+          {/* mask out the guide toggle fab, so we don't have text running behind it */}
+          <Box
+            id="guide-toggle-mask"
+            aria-hidden
+            sx={{
+              float: "right",
+              position: "sticky",
+              top: 0,
+              width: 40,
+              height: 40,
+              mr: "6px",
+              pointerEvents: "none",
+            }}
+          />
           <Markdown
             urlTransform={(url) => {
               if (url.startsWith("data:image/")) {


### PR DESCRIPTION
1. Fix UI glitch, where the new guide toggle button can be hiding some of the guide
<img width="206" height="66" alt="image" src="https://github.com/user-attachments/assets/f8e4e124-6556-409b-884a-f3aa4cb5f67b" />

2. Started improving the book editing infrastructure. On `?teacher=true&coop=1`, we now offer a distinguished edit vs. clone option (the former maintains challenge Ids)
<img width="356" height="289" alt="image" src="https://github.com/user-attachments/assets/4e1a0a21-af92-497f-ac90-dc3770c98a45" />
Furthermore, when opening a local folder (not a zip file) on the same page, we can also open this in the new edit mode (ids maintained). For now, changes are **not** written back to the local folder (they should do in a future release)

